### PR TITLE
Update ArgumentMapTest.java

### DIFF
--- a/test/ArgumentMapTest.java
+++ b/test/ArgumentMapTest.java
@@ -423,7 +423,7 @@ public class ArgumentMapTest {
 		@Test
 		public void testGetIntOkay() {
 			int expected = 42;
-			int actual = map.getInteger("-a", 42);
+			int actual = map.getInteger("-a", 100);
 			Assert.assertEquals(debug, expected, actual);
 		}
 


### PR DESCRIPTION
Provide a defaultValue to testGetIntOkay that differs from the value corresponding to the flag, to ensure correct output.  Otherwise, the test does not distinguish between a successful parse of the string “42” and the defaultValue of 42.